### PR TITLE
Use Discord.js 6.0 and the new Message.cleanContent

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "discord.js": "5.0.1",
+    "discord.js": "6.0.0",
     "parent-require": "^1.0.0"
   },
   "peerDependencies": {

--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -37,16 +37,7 @@ class DiscordBot extends Adapter
         user.room = message.channel
         user.raw_message = message
 
-        # revert the received mention to the raw text
-        text = message.content
-        for mention in message.mentions
-            rex = new RegExp( '<@' + mention.id + '>' )
-            if mention.id == @client.user.id
-                repl = '@' + @robot.name
-            else
-                repl = ''
-            text = text.replace '<@' + mention.id + '>', repl
-        
+        text = message.cleanContent
         @robot.logger.debug text
 
         @receive new TextMessage( user, text, message.id )


### PR DESCRIPTION
This leaves mentions as `@username` in messages.

The only caveat here is that `res.reply res.message.text` won't actually link mentions properly, but… doing that with the current version will just omit mentions altogether, so you already have to use `res.user.raw_message.content`.