### PR TITLE
Remove circular references that break hubot-brain

### DIFF
--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -36,6 +36,7 @@ class DiscordBot extends Adapter
 
         user = @robot.brain.userForId message.author.id
         user.room = message.channel.name
+        user.name = message.author.name
         rooms[message.channel.name] ?= message.channel
 
         text = message.cleanContent

--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -42,6 +42,9 @@ class DiscordBot extends Adapter
         text = message.cleanContent
         @robot.logger.debug text
 
+        if (message.channel instanceof Discord.PMChannel)
+          text = "#{@robot.name}: #{text}"
+
         @receive new TextMessage( user, text, message.id )
 
      send: (envelope, messages...) ->

--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -5,6 +5,7 @@ catch
     {Robot, Adapter, EnterMessage, LeaveMessage, TopicMessage, TextMessage}  = prequire 'hubot'
 Discord = require "discord.js"
 
+rooms = {}
 
 class DiscordBot extends Adapter
     constructor: (robot)->
@@ -33,9 +34,9 @@ class DiscordBot extends Adapter
         # ignore messages from myself
         return if message.author.id == @client.user.id
 
-        user = @robot.brain.userForId message.author
-        user.room = message.channel
-        user.raw_message = message
+        user = @robot.brain.userForId message.author.id
+        user.room = message.channel.name
+        rooms[message.channel.name] ?= message.channel
 
         text = message.cleanContent
         @robot.logger.debug text
@@ -44,7 +45,7 @@ class DiscordBot extends Adapter
 
      send: (envelope, messages...) ->
         for msg in messages
-            @client.sendMessage envelope.room, msg
+            @client.sendMessage rooms[envelope.room], msg
 
      reply: (envelope, messages...) ->
 
@@ -53,7 +54,7 @@ class DiscordBot extends Adapter
 
         user = envelope.user.name
         for msg in messages
-            @client.sendMessage envelope.room, "#{user} #{msg}" 
+            @client.sendMessage rooms[envelope.room], "#{user} #{msg}" 
         
         
 exports.use = (robot) ->


### PR DESCRIPTION
Sorry, screwed up the last PR. Had it based on what was in NPM rather than master.

Anyways, this removes circular references that cause issues like #7 when trying to JSON-serialize to store into redis.