### PR TITLE
Fix the previous wrappers pr

### DIFF
--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -42,7 +42,7 @@ class DiscordBot extends Adapter
         user.room = message.channel
         user.raw_message = message
 
-        text = message.cleanContent
+        text = message.content
         @robot.logger.debug text
 
         @receive new TextMessage( user, text, message.id )


### PR DESCRIPTION
message.cleanContent was moved inside the message wrapper object.  We can safely refer to the content we want as message.content now