### PR TITLE
store rooms based on id instead of name

### DIFF
--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -40,9 +40,9 @@ class DiscordBot extends Adapter
         return if message.author.id == @client.user.id
 
         user = @robot.brain.userForId message.author.id
-        user.room = message.channel.name
+        user.room = message.channel.id
         user.name = message.author.name
-        rooms[message.channel.name] ?= message.channel
+        rooms[message.channel.id] ?= message.channel
 
         text = message.cleanContent
         


### PR DESCRIPTION
Storing rooms based on the channel's id instead of name should resolve the issue of the bot replying in random channels.
should fix https://github.com/thetimpanist/hubot-discord/issues/27