### PR TITLE
Remove ability perform an OAuth login with an e-mail & password

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,14 @@ You should report any issues or submit any pull requests to the
 You will need to create a Discord account for your hubot and then invite the bot
 to the channels you wish it to be present in
 
-    % export HUBOT_DISCORD_EMAIL="..."
-    % export HUBOT_DISCORD_PASSWORD="..."
     % export HUBOT_DISCORD_TOKEN="..."
 
 Environment Variable | Description | Example
 --- | --- | ---
-`HUBOT_DISCORD_EMAIL` | email for your discord hubot | `hubot@example.org`
-`HUBOT_DISCORD_PASSWORD`  | password for your discord hubot | `password`
-`HUBOT_DISCORD_TOKEN` | bot token for your oauth hubot | `MMMMMMMM`
+`HUBOT_DISCORD_TOKEN` | bot token for your oauth hubot | `MMMMMMMM.xxxxx.yyyyyyy`
 
-The OAuth token can be created for an existing bot by [following this guide](https://github.com/DoNotSpamPls/repository/wiki/How-to-convert-your-bot-account-in-the-API).
+The OAuth token is obtained by logging into the [Discord Developer Dashboard](https://discordapp.com/developers/applications/me)
+and creating a new application with an app bot user.
 
 ## Launching your hubot
     

--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -14,8 +14,6 @@ class DiscordBot extends Adapter
 
      run: ->
         @options =
-            email: process.env.HUBOT_DISCORD_EMAIL,
-            password: process.env.HUBOT_DISCORD_PASSWORD,
             token: process.env.HUBOT_DISCORD_TOKEN
             
 
@@ -23,10 +21,7 @@ class DiscordBot extends Adapter
         @client.on 'ready', @.ready
         @client.on 'message', @.message
         
-        if @options.token?
-          @client.loginWithToken @options.token, @options.email, @options.password
-        else
-          @client.login @options.email, @options.password
+        @client.loginWithToken @options.token
 
      ready: =>
         @robot.logger.info 'Logged in: ' + @client.user.username


### PR DESCRIPTION
According to the new Discord Bot API spec, and the latest version of
discord.js, a token alone is now sufficient to login to the official
Discord OAuth API.

This PR is more of a future-proofing and is entirely optional to merge. In discord.js 7.0.0, it's still possible to use the e-mail/password alongside a token. I'm assuming the e-mail/password fields will be removed in the future, as they're not used to actually make the authentication transaction in the discord.js API.