### PR TITLE
Oauth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,11 @@ You should report any issues or submit any pull requests to the
 You will need to create a Discord account for your hubot and then invite the bot
 to the channels you wish it to be present in
 
-    % export HUBOT_DISCORD_EMAIL="..."
-    % export HUBOT_DISCORD_PASSWORD="..."
     % export HUBOT_DISCORD_TOKEN="..."
     % export HUBOT_MAX_MESSAGE_LENGTH="2000"
 
 Environment Variable | Description | Example
 --- | --- | ---
-`HUBOT_DISCORD_EMAIL` | email for your discord hubot | `hubot@example.org`
-`HUBOT_DISCORD_PASSWORD`  | password for your discord hubot | `password`
 `HUBOT_DISCORD_TOKEN` | bot token for your oauth hubot | `MMMMMMMM`
 `HUBOT_MAX_MESSAGE_LENGTH` | maximum message length to send at once | `2000`
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "discord.js": "7.0.0",
+    "discord.js": "8.1.0",
     "parent-require": "^1.0.0"
   },
   "peerDependencies": {

--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -16,8 +16,6 @@ class DiscordBot extends Adapter
      
      run: ->
         @options =
-            email: process.env.HUBOT_DISCORD_EMAIL,
-            password: process.env.HUBOT_DISCORD_PASSWORD,
             token: process.env.HUBOT_DISCORD_TOKEN
         # require oauth token type
         @options.token = "Bot " + @options.token if not @options.token.startsWith "Bot "
@@ -26,12 +24,8 @@ class DiscordBot extends Adapter
         @client.on 'ready', @.ready
         @client.on 'message', @.message
         
-        if @options.token?
-          @client.loginWithToken @options.token, @options.email, @options.password, (err) ->
-            @robot.logger.error err
-        else
-          @client.login @options.email, @options.password, (err) ->
-            @robot.logger.error err
+        @client.loginWithToken @options.token, null, null, (err) ->
+          @robot.logger.error err
 
      ready: =>
         @robot.logger.info 'Logged in: ' + @client.user.username

--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -19,6 +19,8 @@ class DiscordBot extends Adapter
             email: process.env.HUBOT_DISCORD_EMAIL,
             password: process.env.HUBOT_DISCORD_PASSWORD,
             token: process.env.HUBOT_DISCORD_TOKEN
+        # require oauth token type
+        @options.token = "Bot " + @options.token if not @options.token.startsWith "Bot "
 
         @client = new Discord.Client {forceFetchUsers: true, autoReconnect: true}
         @client.on 'ready', @.ready


### PR DESCRIPTION
Long list of overdue updates:

- Bump to discord.js 8.1.0
- Deprecate all username / password logins - I can't think of a reason why a hubot should not be using bot tokens for authentication.
- prefix tokens with required oauth token "Bot "