### PR TITLE
Add res.emote via italics

### DIFF
--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -85,6 +85,10 @@ class DiscordBot extends Adapter
         for message in messages
           @sendMessage envelope.room, "<@#{envelope.user.id}> #{message}"
 
+     emote: (envelope, messages...) ->
+        for message in messages
+          @sendMessage envelope.room, "_#{message}_"
+
      sendMessage: (channelId, message) ->
         errorHandle = (err) ->
           robot.logger.error "Error sending: #{message}\r\n#{err}"


### PR DESCRIPTION
Not sure if you want this in mainline, but this was useful for my server, so I figured I'd submit a PR for it.

Adds some formatting for res.emote. Follows the way Discord handles /me, by surrounding message text with underscores to make it italic.