### PR TITLE
setActivity usage for the Bot's Status

### DIFF
--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -93,7 +93,7 @@ class DiscordBot extends Adapter
 
         #post-connect actions
         @rooms[channel.id] = channel for channel in @client.channels
-        @client.user.setPresence({ status: 'online', game: { name: currentlyPlaying }})
+        @client.user.setActivity(currentlyPlaying)
           .then(@robot.logger.debug("Status set to #{currentlyPlaying}"))
           .catch(@robot.logger.error)
 


### PR DESCRIPTION
`.setActivity` is the new method used to designate the activity that the
bot is performing currently on Discord.

If the user has `HUBOT_DISCORD_STATUS_MSG` as an environment variable,
this will be passed and set as the bot's status with whatever the variable
is set to. This will show up as the bot is "Playing" whatever the string
is.

Example:
`HUBOT_DISCORD_STATUS_MSG="DOOM 2016 OST"`

```
HUBOT
Playing DOOM OST
```