### PR TITLE
Listen for Client Errors and log them.

### DIFF
--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -56,6 +56,8 @@ class DiscordBot extends Adapter
         @client.on 'ready', @.ready
         @client.on 'message', @.message
         @client.on 'disconnected', @.disconnected
+        @client.on 'error', (error) =>
+          @robot.logger.error "The client encountered an error: #{error}"
         @client.on 'messageReactionAdd', (message, user)  => 
           @.message_reaction('reaction_added', message, user)
         @client.on 'messageReactionRemove', (message, user) => 


### PR DESCRIPTION
Currently if there is an error that is being emitted from the client,
there is no method that handles these errors and the bot crashes after
an unspecified amount of time.

This will at least listen to the client's error event and log what the
error was in a graceful manner.